### PR TITLE
fix：admin-product-image

### DIFF
--- a/app/Http/Requests/ProductRequestForStore.php
+++ b/app/Http/Requests/ProductRequestForStore.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\ProductStatus;
+use Illuminate\Validation\Rules\Enum;
+
+class ProductRequestForStore extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'string'],
+            'image' => ['required', 'image'],
+            'introduction' => ['required', 'string'],
+            'price' => ['required', 'integer', 'min:0'],
+            'stock' => ['required', 'integer', 'min:0'],
+            'status' => ['required', new Enum(ProductStatus::class)],
+        ];
+    }
+}

--- a/app/Http/Requests/ProductRequestForUpdate.php
+++ b/app/Http/Requests/ProductRequestForUpdate.php
@@ -6,7 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use App\Enums\ProductStatus;
 use Illuminate\Validation\Rules\Enum;
 
-class ProductRequest extends FormRequest
+class ProductRequestForUpdate extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -27,7 +27,7 @@ class ProductRequest extends FormRequest
     {
         return [
             'name' => ['required', 'string'],
-            'image' => ['required', 'image'],
+            'image' => ['sometimes', 'image'],
             'introduction' => ['required', 'string'],
             'price' => ['required', 'integer', 'min:0'],
             'stock' => ['required', 'integer', 'min:0'],

--- a/resources/js/product.js
+++ b/resources/js/product.js
@@ -1,0 +1,14 @@
+const image = document.getElementById("image");
+const productImage = document.getElementById("productImage");
+
+image.addEventListener("change", showProductImage);
+
+function showProductImage(e) {
+    const reader = new FileReader();
+
+    reader.onload = function (e) {
+        productImage.setAttribute("src", e.target.result);
+    };
+
+    reader.readAsDataURL(e.target.files[0]);
+}

--- a/resources/views/admin/products/create.blade.php
+++ b/resources/views/admin/products/create.blade.php
@@ -20,7 +20,8 @@
                         <div class="p-2 w-full">
                             <div class="relative">
                                 <x-input-label>画像</x-input-label><br>
-                                <input type="file" name="image">
+                                <input type="file" id="image" name="image">
+                                <img id="productImage">
                                 <x-input-error :messages="$errors->get('image')" class="mt-2" />
                             </div>
                         </div>
@@ -71,4 +72,7 @@
             </div>
         </form>
     </section>
+    @push('script')
+    @vite(['resources/js/product.js'])
+    @endpush
 </x-admin-layout>

--- a/resources/views/admin/products/edit.blade.php
+++ b/resources/views/admin/products/edit.blade.php
@@ -22,7 +22,8 @@
                         <div class="p-2 w-full">
                             <div class="relative">
                                 <x-input-label>画像</x-input-label><br>
-                                <input type="file" name="image">
+                                <input type="file" id="image" name="image">
+                                <img id="productImage" src="{{ asset('storage/image/' . $product->image) }}">
                                 <x-input-error :messages="$errors->get('image')" class="mt-2" />
                             </div>
                         </div>
@@ -74,4 +75,7 @@
             </div>
         </form>
     </section>
+    @push('script')
+    @vite(['resources/js/product.js'])
+    @endpush
 </x-admin-layout>

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -43,6 +43,7 @@
             </div>
         </main>
     </div>
+    @stack('script')
 </body>
 
 </html>


### PR DESCRIPTION
商品編集の際、画像を毎回登録する必要性を排除するため、ProductRequestをstoreとupdateで分割しました。また、画像のプレビュー機能がありませんので、jsで実装しました。
![image](https://user-images.githubusercontent.com/117799363/216467730-eafa1a6c-6a2a-4bef-b094-e64ac331ec44.png)
