### PR TITLE
fix：user-order-confirm

### DIFF
--- a/resources/views/orders/confirm.blade.php
+++ b/resources/views/orders/confirm.blade.php
@@ -120,7 +120,7 @@ use App\Helpers\Calculator;
                         data-key="{{ env('STRIPE_PUBLIC_KEY') }}" data-amount="{{ $sum + $shipping }}"
                         data-name="Stripe Demo" data-label="注文を確定する" data-description="これはデモ決済です"
                         data-image="https://stripe.com/img/documentation/checkout/marketplace.png" data-locale="auto"
-                        data-currency="JPY">
+                        data-currency="JPY" data-email="{{ Auth::user()->email }}">
                     </script>
                 </form>
             </div>


### PR DESCRIPTION
決済時に必要となるメールアドレスを予め設定しました。
![image](https://user-images.githubusercontent.com/117799363/216768187-29df66f4-79f9-4870-90c1-71a48bef2653.png)
