### PR TITLE
fix：user-order-confirm

### DIFF
--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -64,7 +64,7 @@ class OrderController extends Controller
         }
 
         $addAddress = [
-            'address' => $request->address,
+            'address' => $request->selectedAddress,
             'name' => $request->name,
             'postal_code' => $request->postal_code,
             'pref_id' => $request->pref_id,
@@ -95,7 +95,7 @@ class OrderController extends Controller
             $order->shipping_fee = Area::find(config('area')[session('address')['pref_id']])->currentShippingFee->fee;
             $order->save();
 
-            if (session('address')['address'] == 'newAddress') {
+            if (session('address')['selectedAddress'] == 'newAddress') {
                 Address::create([
                     'user_id' => Auth::id(),
                     'name' => $order->name,
@@ -121,13 +121,13 @@ class OrderController extends Controller
                 $product->stock -= $cartProduct['quantity'];
                 $product->save();
             }
-        });
 
-        Charge::create(array(
-            'amount' => Calculator::orderSum($order),
-            'currency' => 'jpy',
-            'customer' => Auth::user()->stripe_id,
-        ));
+            Charge::create(array(
+                'amount' => Calculator::orderSum($order),
+                'currency' => 'jpy',
+                'customer' => Auth::user()->stripe_id,
+            ));
+        });
 
         Mail::to(Auth::user())->send(new OrderMail($order));
 

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -6,18 +6,25 @@ use App\Models\Address;
 use App\Models\Order;
 use App\Models\OrderDetail;
 use App\Models\Product;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
-use Stripe\Stripe;
 use Stripe\Charge;
 use App\Helpers\Calculator;
 use App\Http\Requests\AddressRequest;
 use App\Mail\OrderMail;
 use App\Models\Area;
+use App\Services\StripeService;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 
 class OrderController extends Controller
 {
+    private StripeService $stripeService;
+
+    public function __construct(StripeService $stripeService)
+    {
+        $this->stripeService = $stripeService;
+    }
+
     public function index()
     {
         $maxRecords = 5;
@@ -35,8 +42,9 @@ class OrderController extends Controller
         }
 
         $addresses = Auth::user()->addresses;
+        $card = $this->stripeService->getCard(Auth::user());
 
-        return view('orders.create', compact('addresses'));
+        return view('orders.create', compact('addresses', 'card'));
     }
 
     public function confirm(AddressRequest $request)
@@ -67,56 +75,58 @@ class OrderController extends Controller
 
         session()->put('address', $addAddress);
 
-        return view('orders.confirm');
+        $card = $this->stripeService->getCard(Auth::user());
+
+        return view('orders.confirm', compact('card'));
     }
 
-    public function store(Request $request)
+    public function store()
     {
         $order = new Order;
 
-        $order->user_id = Auth::id();
-        $order->name = session('address')['name'];
-        $order->postal_code = session('address')['postal_code'];
-        $order->pref_id = session('address')['pref_id'];
-        $order->address1 = session('address')['address1'];
-        $order->address2 = session('address')['address2'];
-        $order->phone_number = session('address')['phone_number'];
-        $order->shipping_fee = Area::find(config('area')[session('address')['pref_id']])->currentShippingFee->fee;
-        $order->save();
+        DB::transaction(function () use ($order) {
+            $order->user_id = Auth::id();
+            $order->name = session('address')['name'];
+            $order->postal_code = session('address')['postal_code'];
+            $order->pref_id = session('address')['pref_id'];
+            $order->address1 = session('address')['address1'];
+            $order->address2 = session('address')['address2'];
+            $order->phone_number = session('address')['phone_number'];
+            $order->shipping_fee = Area::find(config('area')[session('address')['pref_id']])->currentShippingFee->fee;
+            $order->save();
 
-        if (session('address')['address'] == 'newAddress') {
-            Address::create([
-                'user_id' => Auth::id(),
-                'name' => $order->name,
-                'postal_code' => $order->postal_code,
-                'pref_id' => $order->pref_id,
-                'address1' => $order->address1,
-                'address2' => $order->address2,
-                'phone_number' => $order->phone_number,
-            ]);
-        }
+            if (session('address')['address'] == 'newAddress') {
+                Address::create([
+                    'user_id' => Auth::id(),
+                    'name' => $order->name,
+                    'postal_code' => $order->postal_code,
+                    'pref_id' => $order->pref_id,
+                    'address1' => $order->address1,
+                    'address2' => $order->address2,
+                    'phone_number' => $order->phone_number,
+                ]);
+            }
 
-        foreach (session('cart') as $cartProduct) {
-            OrderDetail::create([
-                'order_id' => $order->id,
-                'product_id' => $cartProduct['id'],
-                'price' => $cartProduct['price'],
-                'quantity' => $cartProduct['quantity'],
-                'tax_rate' => config('app')['tax_rate'],
-            ]);
+            foreach (session('cart') as $cartProduct) {
+                OrderDetail::create([
+                    'order_id' => $order->id,
+                    'product_id' => $cartProduct['id'],
+                    'price' => $cartProduct['price'],
+                    'quantity' => $cartProduct['quantity'],
+                    'tax_rate' => config('app')['tax_rate'],
+                ]);
 
-            $product = Product::find($cartProduct['id']);
+                $product = Product::find($cartProduct['id']);
 
-            $product->stock -= $cartProduct['quantity'];
-            $product->save();
-        }
-
-        Stripe::setApiKey(config('app.stripe_secret_key'));
+                $product->stock -= $cartProduct['quantity'];
+                $product->save();
+            }
+        });
 
         Charge::create(array(
             'amount' => Calculator::orderSum($order),
             'currency' => 'jpy',
-            'source' => $request->stripeToken,
+            'customer' => Auth::user()->stripe_id,
         ));
 
         Mail::to(Auth::user())->send(new OrderMail($order));

--- a/app/Http/Requests/AddressRequest.php
+++ b/app/Http/Requests/AddressRequest.php
@@ -36,7 +36,7 @@ class AddressRequest extends FormRequest
 
     protected function prepareForValidation()
     {
-        if ($this->address == 'registeredAddress') {
+        if ($this->selectedAddress == 'registeredAddress') {
             $address = Address::find($this->addressId);
 
             $data['name'] = $address->name;

--- a/resources/css/style.css
+++ b/resources/css/style.css
@@ -1,5 +1,0 @@
-button.stripe-button-el,
-button.stripe-button-el > span {
-    background-color: rgb(220 38 38) !important;
-    background-image: none;
-}

--- a/resources/js/address.js
+++ b/resources/js/address.js
@@ -1,6 +1,6 @@
 window.onload = switchAddress;
 
-const addressRadios = document.getElementsByName("address");
+const addressRadios = document.getElementsByName("selectedAddress");
 for (let i = 0; i < addressRadios.length; i++) {
     addressRadios[i].addEventListener("click", switchAddress);
 }

--- a/resources/views/orders/confirm.blade.php
+++ b/resources/views/orders/confirm.blade.php
@@ -110,6 +110,20 @@ use App\Models\Area;
             </tr>
         </table>
 
+        <table class="table-auto w-full text-left whitespace-no-wrap mb-6">
+            <caption class="px-4 py-3 title-font tracking-wider font-medium text-gray-900 text-sm bg-gray-100">
+                カード情報
+            </caption>
+            <tr>
+                <x-th>カード番号</x-th>
+                <x-td>{{ $card['number'] }}</x-td>
+            </tr>
+            <tr>
+                <x-th>有効期限</x-th>
+                <x-td class="border-b-2">{{ $card['exp'] }}</x-td>
+            </tr>
+        </table>
+
         <div class="flex">
             <div class="flex mx-auto">
                 <x-primary-button onclick="history.back();">
@@ -118,18 +132,10 @@ use App\Models\Area;
 
                 <form class="ml-4" method="post" action="{{ route('orders.store') }}">
                     @csrf
-                    <script src="https://checkout.stripe.com/checkout.js" class="stripe-button"
-                        data-key="{{ env('STRIPE_PUBLIC_KEY') }}" data-amount="{{ $sum + $shipping }}"
-                        data-name="Stripe Demo" data-label="注文を確定する" data-description="これはデモ決済です"
-                        data-image="https://stripe.com/img/documentation/checkout/marketplace.png" data-locale="auto"
-                        data-currency="JPY" data-email="{{ Auth::user()->email }}">
-                    </script>
+                    <x-danger-button>注文を確定する</x-danger-button>
                 </form>
             </div>
         </div>
         @endif
     </div>
-    @push('style')
-    @vite(['resources/css/style.css'])
-    @endpush
 </x-app-layout>

--- a/resources/views/orders/create.blade.php
+++ b/resources/views/orders/create.blade.php
@@ -93,6 +93,7 @@
                         </div>
                     </div>
 
+                    @if ($card)
                     <div class="flex flex-wrap -m-2">
                         <div class="p-2 w-full text-center">
                             <x-primary-button>
@@ -100,6 +101,7 @@
                             </x-primary-button>
                         </div>
                     </div>
+                    @endif
                 </div>
             </div>
             </div>

--- a/resources/views/orders/create.blade.php
+++ b/resources/views/orders/create.blade.php
@@ -12,9 +12,10 @@
                         <div class="p-2 w-full">
                             <div class="relative">
                                 <x-input-label>配送先</x-input-label><br>
-                                <input type="radio" id="registeredAddress" name="address" value="registeredAddress" {{
-                                    old('address')=="registeredAddress" ? 'checked' : '' }} checked>登録済住所から選択
-                                <input type="radio" id="newAddress" name="address" value="newAddress" {{
+                                <input type="radio" id="registeredAddress" name="selectedAddress"
+                                    value="registeredAddress" {{ old('address')=="registeredAddress" ? 'checked' : '' }}
+                                    checked>登録済住所から選択
+                                <input type="radio" id="newAddress" name="selectedAddress" value="newAddress" {{
                                     old('address')=="newAddress" ? 'checked' : '' }} required>新しい配送先
                             </div>
                         </div>


### PR DESCRIPTION
注文確認画面にカード情報欄を追加し、登録しているカードで決済できるよう変更しました。
なお、配送先入力画面でカード情報の変更をできるよう実装する予定でしたが、非同期通信がうまく動作しなかったため、一旦カードを登録していない会員については注文確認画面に飛べないようにしております。

![image](https://user-images.githubusercontent.com/117799363/218910494-48521288-e984-476d-8372-280dd6aca2ed.png)
