### PR TITLE
fix：user-order-store

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,7 @@ Route::middleware('auth')->group(function () {
         Route::get('/', 'index')->name('index');
         Route::get('/create', 'create')->name('create');
         Route::post('/confirm', 'confirm')->name('confirm');
+        Route::get('/short', 'short')->name('short');
         Route::post('/', 'store')->name('store');
         Route::get('/{order}', 'show')->name('show');
     });


### PR DESCRIPTION
注文確認画面が描画されてから決済までに在庫確認を行っていませんでしたので、「注文確定ボタン」を押すと在庫確認を再度行い、在庫数を上回る注文があれば再度注文確認画面にリダイレクトされるよう実装しました。
また、悲観ロックをlockForUpdateメソッドを使用して実装しましたので、ご確認のほどよろしくお願いいたします。
![image](https://user-images.githubusercontent.com/117799363/219302796-cc6d44f9-880e-4c6e-ab96-08efbd936382.png)
![image](https://user-images.githubusercontent.com/117799363/219303366-83afebfa-3243-466e-a180-70d9380059be.png)

